### PR TITLE
r/aws_rds_cluster_parameter_group and r/aws_db_parameter_group: Resto…

### DIFF
--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -277,8 +277,25 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
+		toRemove := map[string]*rds.Parameter{}
+
+		for _, p := range expandParameters(os.List()) {
+			if p.ParameterName != nil {
+				toRemove[*p.ParameterName] = p
+			}
+		}
+
+		for _, p := range expandParameters(ns.List()) {
+			if p.ParameterName != nil {
+				delete(toRemove, *p.ParameterName)
+			}
+		}
+
 		// Reset parameters that have been removed
-		resetParameters := expandParameters(os.Difference(ns).List())
+		var resetParameters []*rds.Parameter
+		for _, v := range toRemove {
+			resetParameters = append(resetParameters, v)
+		}
 		if len(resetParameters) > 0 {
 			maxParams := 20
 			for resetParameters != nil {

--- a/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -376,6 +376,65 @@ func TestAccAWSDBClusterParameterGroup_only(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBClusterParameterGroup_updateParameters(t *testing.T) {
+	var v rds.DBClusterParameterGroup
+	resourceName := "aws_rds_cluster_parameter_group.test"
+	groupName := fmt.Sprintf("cluster-parameter-group-test-tf-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBClusterParameterGroupUpdateParametersInitialConfig(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
+					testAccCheckAWSDBClusterParameterGroupAttributes(&v, groupName),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "aurora5.6"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "character_set_results",
+						"value": "utf8",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "character_set_server",
+						"value": "utf8",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "character_set_client",
+						"value": "utf8",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDBClusterParameterGroupUpdateParametersUpdatedConfig(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
+					testAccCheckAWSDBClusterParameterGroupAttributes(&v, groupName),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "character_set_results",
+						"value": "ascii",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "character_set_server",
+						"value": "ascii",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "character_set_client",
+						"value": "utf8",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSDBClusterParameterGroupDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
@@ -619,6 +678,54 @@ func testAccAWSDBClusterParameterGroupOnlyConfig(name string) string {
 resource "aws_rds_cluster_parameter_group" "test" {
   name   = "%s"
   family = "aurora5.6"
+}
+`, name)
+}
+
+func testAccAWSDBClusterParameterGroupUpdateParametersInitialConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster_parameter_group" "test" {
+  name   = "%s"
+  family = "aurora5.6"
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8"
+  }
+
+  parameter {
+    name  = "character_set_client"
+    value = "utf8"
+  }
+
+  parameter {
+    name  = "character_set_results"
+    value = "utf8"
+  }
+}
+`, name)
+}
+
+func testAccAWSDBClusterParameterGroupUpdateParametersUpdatedConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster_parameter_group" "test" {
+  name   = "%s"
+  family = "aurora5.6"
+
+  parameter {
+    name  = "character_set_server"
+    value = "ascii"
+  }
+
+  parameter {
+    name  = "character_set_client"
+    value = "utf8"
+  }
+
+  parameter {
+    name  = "character_set_results"
+    value = "ascii"
+  }
 }
 `, name)
 }


### PR DESCRIPTION
This repo is a fork of https://github.com/terraform-providers/terraform-provider-aws at version 2.70.0, the last version that supports tf 0.11.

This PR pulls in https://github.com/terraform-providers/terraform-provider-aws/pull/12112 as a step toward resolving https://samsaradev.atlassian.net/browse/RE-636

After this PR, I'll build a custom terraform provider binary and switch our aws pipelines to use the custom provider instead of the official terraform AWS provider. I'll wait for https://github.com/samsara-dev/backend/pull/79079 before doing that.